### PR TITLE
Handle null license case in BreakingUpdate.java

### DIFF
--- a/src/main/java/miner/BreakingUpdate.java
+++ b/src/main/java/miner/BreakingUpdate.java
@@ -8,6 +8,7 @@ import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.kohsuke.github.GHPullRequest;
 import org.kohsuke.github.GHRepository;
 import org.kohsuke.github.GHUser;
+import org.kohsuke.github.GHLicense;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -59,7 +60,8 @@ public class BreakingUpdate {
         projectOrganisation = url.split("/")[3];
         breakingCommit = pr.getHead().getSha();
         try {
-            licenseInfo = pr.getRepository().getLicense().getName();
+            GHLicense license = pr.getRepository().getLicense();
+            licenseInfo = (license != null) ? license.getName() : "unknown";
         } catch (IOException e) {
             licenseInfo = "unknown";
         }


### PR DESCRIPTION
Fixes how license information is retrieved from a repository. The code now checks if a license exists before accessing its name, and sets the license information to "unknown" if it's not available. This prevents errors when a repository has no license.